### PR TITLE
Replace deprecated validate-functions with data types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,31 +3,19 @@
 # Manage /etc/hosts
 #
 class hosts (
-  $file             = '/etc/hosts',
-  $lo_ipv4          = split($ipv4_lo_addrs,' '),
-  $lo_ipv6          = split($ipv6_lo_addrs,' '),
-  $lo_names         = [ 'localhost' ],
-  $one_primary_ipv4 = true,
-  $one_primary_ipv6 = true,
-  $enable_ipv4      = true,
-  $enable_ipv6      = true,
-  $primary_ipv4     = split($ipv4_pri_addrs,' '),
-  $primary_ipv6     = split($ipv6_pri_addrs,' '),
-  $primary_names    = [ $::fqdn, $::hostname ],
-  $entries          = {},
+  Stdlib::Absolutepath $file   = '/etc/hosts',
+  Array[String] $lo_ipv4       = split($ipv4_lo_addrs,' '),
+  Array[String] $lo_ipv6       = split($ipv6_lo_addrs,' '),
+  Array[String] $lo_names      = [ 'localhost' ],
+  Boolean $one_primary_ipv4    = true,
+  Boolean $one_primary_ipv6    = true,
+  Boolean $enable_ipv4         = true,
+  Boolean $enable_ipv6         = true,
+  Array[String] $primary_ipv4  = split($ipv4_pri_addrs,' '),
+  Array[String] $primary_ipv6  = split($ipv6_pri_addrs,' '),
+  Array[String] $primary_names = [ $::fqdn, $::hostname ],
+  Hash $entries                = {},
 ) {
-  validate_string($file)
-  validate_array($lo_ipv4)
-  validate_array($lo_ipv6)
-  validate_array($lo_names)
-  validate_bool($one_primary_ipv4)
-  validate_bool($one_primary_ipv6)
-  validate_bool($enable_ipv4)
-  validate_bool($enable_ipv6)
-  validate_array($primary_ipv4)
-  validate_array($primary_ipv6)
-  validate_array($primary_names)
-  validate_hash($entries)
   case $::osfamily {
     /^(FreeBSD|DragonFly|Darwin)$/: {
       $root_group = 'wheel'
@@ -55,8 +43,10 @@ class hosts (
     $loopback_ipv6 = $lo_ipv6
     $pri_ipv6 = $primary_ipv6
   }
+
   $entries_output = hiera_hash('hosts::entries', $entries)
-  validate_hash($entries_output)
+  assert_type(Hash, $entries_output)
+
   file { $file:
     ensure  => present,
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "chrekh-hosts",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "author": "chrekh",
   "summary": "A template-based module to manage /etc/hosts",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0 < 6.0.0"
+      "version_requirement": ">= 4.13.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 4.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
This PR replaces the deprecated validate-functions with valid data types. These types got introduced with puppet 4.