### PR TITLE
Don't sort addresses if one_primary_ipx is true.

### DIFF
--- a/lib/facter/list_addrs.rb
+++ b/lib/facter/list_addrs.rb
@@ -50,21 +50,21 @@ end
 
 Facter.add('ipv4_lo_addrs') do
   setcode do
-    lo_ipv4.uniq.sort.join(' ')
+    lo_ipv4.uniq.join(' ')
   end
 end
 Facter.add('ipv4_pri_addrs') do
   setcode do
-    primary_ipv4.uniq.sort.join(' ')
+    primary_ipv4.uniq.join(' ')
   end
 end
 Facter.add('ipv6_lo_addrs') do
   setcode do
-    lo_ipv6.uniq.sort.join(' ')
+    lo_ipv6.uniq.join(' ')
   end
 end
 Facter.add('ipv6_pri_addrs') do
   setcode do
-    primary_ipv6.uniq.sort.join(' ')
+    primary_ipv6.uniq.join(' ')
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,16 +36,16 @@ class hosts (
     $pri_ipv4 = [ $primary_ipv4[0] ]
   }
   else {
-    $loopback_ipv4 = $lo_ipv4
-    $pri_ipv4 = $primary_ipv4
+    $loopback_ipv4 = $lo_ipv4.sort
+    $pri_ipv4 = $primary_ipv4.sort
   }
   if $one_primary_ipv6 {
     $loopback_ipv6 = [ $lo_ipv6[0] ]
     $pri_ipv6 = [ $primary_ipv6[0] ]
   }
   else {
-    $loopback_ipv6 = $lo_ipv6
-    $pri_ipv6 = $primary_ipv6
+    $loopback_ipv6 = $lo_ipv6.sort
+    $pri_ipv6 = $primary_ipv6.sort
   }
 
   $entries_output = lookup('hosts::entries', Hash, 'hash', $entries)


### PR DESCRIPTION
Fix for issue #20, sorting addresses before selecting the first one is causing
the wrong IP to be selected. Fix this by moving the sorting from the fact ruby
code to init.pp and only sort when one_primary_ipx is in effect.